### PR TITLE
feat: add persistent unlock logic

### DIFF
--- a/src/components/roadmap/RoadmapContainer.tsx
+++ b/src/components/roadmap/RoadmapContainer.tsx
@@ -19,14 +19,12 @@ interface RoadmapContainerProps {
 
 export function RoadmapContainer({ skillId, stages, onStageSelect }: RoadmapContainerProps) {
   const navigate = useNavigate();
-  const {
-    progress,
-    updateVideoProgress,
-    completeQuiz,
-    isStageUnlocked,
-    getOverallProgress,
-    getCurrentStage,
-  } = useUnlockLogic(skillId);
+    const {
+      progress,
+      updateVideoProgress,
+      completeQuiz,
+      isStageUnlocked,
+    } = useUnlockLogic(skillId, stages.length);
 
   const handleStartStage = (stageId: string) => {
     // Navigate to the learning page

--- a/src/hooks/useUnlockLogic.ts
+++ b/src/hooks/useUnlockLogic.ts
@@ -11,64 +11,89 @@ export interface RoadmapProgress {
   [stageId: string]: StageProgress;
 }
 
-export function useUnlockLogic(skillId: string) {
+export function useUnlockLogic(skillId: string, totalStages: number) {
   const [progress, setProgress] = useState<RoadmapProgress>({});
+  const storageKey = `progress-${skillId}`;
 
-  // Initialize progress for all stages
+  // Initialize progress for all stages or load from localStorage
   useEffect(() => {
+    const stored = typeof window !== 'undefined' ? localStorage.getItem(storageKey) : null;
+    if (stored) {
+      try {
+        setProgress(JSON.parse(stored));
+        return;
+      } catch {
+        // If parsing fails, fall back to initialization below
+      }
+    }
+
     const initialProgress: RoadmapProgress = {};
-    for (let i = 1; i <= 6; i++) {
+    for (let i = 1; i <= totalStages; i++) {
       initialProgress[`stage-${i}`] = {
-        videoWatchPercentage: i === 1 ? 0 : 0, // First stage starts unlocked
+        videoWatchPercentage: 0,
         quizCompleted: false,
         isCompleted: false,
       };
     }
     setProgress(initialProgress);
-  }, [skillId]);
+    if (typeof window !== 'undefined') {
+      localStorage.setItem(storageKey, JSON.stringify(initialProgress));
+    }
+  }, [skillId, totalStages]);
 
   const updateVideoProgress = (stageId: string, percentage: number) => {
-    setProgress(prev => ({
-      ...prev,
-      [stageId]: {
-        ...prev[stageId],
-        videoWatchPercentage: percentage,
-        isCompleted: percentage >= 30 && prev[stageId]?.quizCompleted
+    setProgress(prev => {
+      const updated = {
+        ...prev,
+        [stageId]: {
+          ...prev[stageId],
+          videoWatchPercentage: percentage,
+          isCompleted: percentage >= 30 && prev[stageId]?.quizCompleted,
+        },
+      };
+      if (typeof window !== 'undefined') {
+        localStorage.setItem(storageKey, JSON.stringify(updated));
       }
-    }));
+      return updated;
+    });
   };
 
   const completeQuiz = (stageId: string) => {
-    setProgress(prev => ({
-      ...prev,
-      [stageId]: {
-        ...prev[stageId],
-        quizCompleted: true,
-        isCompleted: prev[stageId]?.videoWatchPercentage >= 30
+    setProgress(prev => {
+      const updated = {
+        ...prev,
+        [stageId]: {
+          ...prev[stageId],
+          quizCompleted: true,
+          isCompleted: prev[stageId]?.videoWatchPercentage >= 30,
+        },
+      };
+      if (typeof window !== 'undefined') {
+        localStorage.setItem(storageKey, JSON.stringify(updated));
       }
-    }));
+      return updated;
+    });
   };
 
   const isStageUnlocked = (stageIndex: number): boolean => {
     if (stageIndex === 0) return true; // First stage always unlocked
-    
+
     const previousStageId = `stage-${stageIndex}`;
     return progress[previousStageId]?.isCompleted || false;
   };
 
   const getOverallProgress = (): number => {
-    const totalStages = 6;
     const completedStages = Object.values(progress).filter(stage => stage.isCompleted).length;
     return Math.round((completedStages / totalStages) * 100);
   };
 
   const getCurrentStage = (): number => {
-    for (let i = 1; i <= 6; i++) {
+    for (let i = 1; i <= totalStages; i++) {
       if (!progress[`stage-${i}`]?.isCompleted) {
         return i;
       }
     }
-    return 6; // All completed
+    return totalStages; // All completed
   };
 
   return {

--- a/src/pages/LearningPage.tsx
+++ b/src/pages/LearningPage.tsx
@@ -64,7 +64,7 @@ const transition = { type: "spring", bounce: 0, duration: 0.4 };
 const LearningPage = () => {
   const { skillId, stageId } = useParams();
   const navigate = useNavigate();
-  const { updateVideoProgress, completeQuiz } = useUnlockLogic(skillId || '');
+  const { updateVideoProgress, completeQuiz } = useUnlockLogic(skillId || '', 6);
   const [activeTab, setActiveTab] = useState("video");
   const [activeNotification, setActiveNotification] = useState<string | null>(null);
 

--- a/src/pages/Roadmap.tsx
+++ b/src/pages/Roadmap.tsx
@@ -29,8 +29,6 @@ const Roadmap = () => {
   };
 
   const currentSkill = skillData[skillId as keyof typeof skillData] || skillData['javascript-typescript'];
-  
-  const { getOverallProgress, getCurrentStage } = useUnlockLogic(skillId || 'javascript-typescript');
 
   // Mock stages data
   const stages = [
@@ -84,6 +82,11 @@ const Roadmap = () => {
     },
   ];
 
+  const { getOverallProgress, getCurrentStage } = useUnlockLogic(
+    skillId || 'javascript-typescript',
+    stages.length
+  );
+
   const handleStageSelect = (stageId: string) => {
     console.log('Navigate to learning page for stage:', stageId);
     // Here you would navigate to the actual learning page
@@ -128,7 +131,7 @@ const Roadmap = () => {
         {/* Progress Tracker */}
         <ProgressTracker
           currentStage={getCurrentStage()}
-          totalStages={6}
+          totalStages={stages.length}
           overallProgress={getOverallProgress()}
           skillTitle={currentSkill.title}
         />


### PR DESCRIPTION
## Summary
- allow dynamic stage counts in unlock logic
- persist video/quiz progress per skill in localStorage
- pass stage totals through roadmap components

## Testing
- `npm run lint` (fails: Unexpected any etc.)
- `npm test` (fails: Missing script)
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b28c8b4054832b8842df78e5b3c1eb